### PR TITLE
Contributions to keep #801 moving forward: ability to start sessions automatically after Android boots

### DIFF
--- a/app/src/main/java/tech/ula/MainActivity.kt
+++ b/app/src/main/java/tech/ula/MainActivity.kt
@@ -97,6 +97,10 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
                         val type = intent.getStringExtra("dialogType") ?: ""
                         showDialog(type)
                     }
+                    "startCommandFailed" -> {
+                        val errorMessage = intent.getStringExtra("error") ?: ""
+                        showDialog(errorMessage)
+                    }
                 }
             }
         }
@@ -425,9 +429,18 @@ class MainActivity : AppCompatActivity(), SessionListFragment.SessionSelection, 
                 displayGenericErrorDialog(this, R.string.general_error_title,
                         R.string.illegal_state_unhandled_session_service_type)
             }
-            "playStoreMissingForClient" ->
+            "playStoreMissingForClient" -> {
                 displayGenericErrorDialog(this, R.string.alert_need_client_app_title,
-                    R.string.alert_need_client_app_message)
+                        R.string.alert_need_client_app_message)
+            }
+            "Failed to execute Start Command: Start script does not exist." -> {
+                displayGenericErrorDialog(this, R.string.alert_need_start_script_title,
+                        R.string.alert_need_start_script_message)
+            }
+            "Failed to execute Start Command: Profile script does not exist." -> {
+                displayGenericErrorDialog(this, R.string.alert_need_profile_script_title,
+                        R.string.alert_need_profile_script_message)
+            }
         }
     }
 

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -181,8 +181,7 @@ class ServerService : Service() {
 
         try {
             serverUtility.executeStartCommand(session)
-        }
-        catch (e: IllegalStateException) {
+        } catch (e: IllegalStateException) {
             // TODO Send an intent to the MainActivity, message contains problem
             // val dialogIntent = Intent(this, MyActivity::class.java)
             // dialogIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -182,11 +182,10 @@ class ServerService : Service() {
         try {
             serverUtility.executeStartCommand(session)
         } catch (e: IllegalStateException) {
-            // TODO Send an intent to the MainActivity, message contains problem
-            // val dialogIntent = Intent(this, MyActivity::class.java)
-            // dialogIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            // dialogIntent.putExtra("startBootFailed", true)
-            // startActivity(dialogIntent)
+            val intent = Intent(SERVER_SERVICE_RESULT)
+                    .putExtra("type", "startCommandFailed")
+                    .putExtra("error", e.message)
+            broadcaster.sendBroadcast(intent)
         }
 
         session.active = true

--- a/app/src/main/java/tech/ula/ServerService.kt
+++ b/app/src/main/java/tech/ula/ServerService.kt
@@ -179,7 +179,16 @@ class ServerService : Service() {
             }
         } else session.pid = 0
 
-        serverUtility.executeStartCommand(session)
+        try {
+            serverUtility.executeStartCommand(session)
+        }
+        catch (e: IllegalStateException) {
+            // TODO Send an intent to the MainActivity, message contains problem
+            // val dialogIntent = Intent(this, MyActivity::class.java)
+            // dialogIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            // dialogIntent.putExtra("startBootFailed", true)
+            // startActivity(dialogIntent)
+        }
 
         session.active = true
         updateSession(session)

--- a/app/src/main/java/tech/ula/utils/ServerUtility.kt
+++ b/app/src/main/java/tech/ula/utils/ServerUtility.kt
@@ -67,8 +67,8 @@ class ServerUtility(
         val startScript = File(applicationFilesDirPath, "$filesystemDirName/support/autostart.sh")
         val profileScript = File(applicationFilesDirPath, "$filesystemDirName/support/userland_profile.sh")
 
-        if (!startScript.exists()) throw IllegalStateException("Start script does not exist.")
-        if (!profileScript.exists()) throw IllegalStateException("Profile script does not exist.")
+        if (!startScript.exists()) throw IllegalStateException("Failed to execute Start Command: Start script does not exist.")
+        if (!profileScript.exists()) throw IllegalStateException("Failed to execute Start Command: Profile script does not exist.")
 
         profileScript.copyTo(startScript, overwrite = true)
         startScript.appendText("\n${session.startCommand}")

--- a/app/src/main/java/tech/ula/utils/ServerUtility.kt
+++ b/app/src/main/java/tech/ula/utils/ServerUtility.kt
@@ -58,12 +58,18 @@ class ServerUtility(
      * Execute the user-defined startCommand
      * Creates a new script based on userland_profile.sh and adds the user-defined command to the script
      */
+    // TODO Refactor function. Move function to BusyboxExecutor. This function is not explicitly related to servers
     fun executeStartCommand(session: Session) {
         if (session.startCommand.isEmpty())
             return
+
         val filesystemDirName = session.filesystemId.toString()
         val startScript = File(applicationFilesDirPath, "$filesystemDirName/support/autostart.sh")
         val profileScript = File(applicationFilesDirPath, "$filesystemDirName/support/userland_profile.sh")
+
+        if(!startScript.exists()) throw IllegalStateException("Start script does not exist.")
+        if(!profileScript.exists()) throw IllegalStateException("Profile script does not exist.")
+
         profileScript.copyTo(startScript, overwrite = true)
         startScript.appendText("\n${session.startCommand}")
         startScript.setExecutable(true, false)

--- a/app/src/main/java/tech/ula/utils/ServerUtility.kt
+++ b/app/src/main/java/tech/ula/utils/ServerUtility.kt
@@ -67,8 +67,8 @@ class ServerUtility(
         val startScript = File(applicationFilesDirPath, "$filesystemDirName/support/autostart.sh")
         val profileScript = File(applicationFilesDirPath, "$filesystemDirName/support/userland_profile.sh")
 
-        if(!startScript.exists()) throw IllegalStateException("Start script does not exist.")
-        if(!profileScript.exists()) throw IllegalStateException("Profile script does not exist.")
+        if (!startScript.exists()) throw IllegalStateException("Start script does not exist.")
+        if (!profileScript.exists()) throw IllegalStateException("Profile script does not exist.")
 
         profileScript.copyTo(startScript, overwrite = true)
         startScript.appendText("\n${session.startCommand}")

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -37,6 +37,7 @@
     <string name="hint_username">Usuário</string>
     <string name="hint_password">Senha</string>
     <string name="hint_vnc_password">Senha VNC</string>
+    <string name="hint_autostart_command">Execute commando na inicialização</string>
     
     <!-- Errors -->
     <string name="error_session_name">Você deve fornecer um nome de sessão</string>
@@ -105,13 +106,20 @@
     <string name="prompt_app_connection_type_preference">Por favor, selecione um tipo de conexão: </string>
     <string name="prompt_select_backup">Selecione o backup do sistema de arquivos</string>
     <string name="prompt_install_file_manager">Por favor, instale um gerenciador de arquivos</string>
+    <string name="prompt_session_start_boot">Inicializar no boot</string>
+    <string name="prompt_session_start_server">Iniciar servidor</string>
+    <string name="prompt_session_start_client">Iniciar cliente</string>
 
     <!-- Notification strings -->
     <string name="services_notification_channel_id">UserLAndServices</string>
     <string name="services_notification_channel_name">Serviços</string>
     <string name="services_notification_channel_description">Serviços persistentes</string>
     <string name="service_notification_title">UserLAnd</string>
+    <string name="service_notification_title_wakelocked">UserLAnd (Wake Locked)</string>
     <string name="service_notification_description">UserLAnd está executando um serviço em segundo plano.</string>
+    <string name="service_notification_exit">Sair</string>
+    <string name="service_notification_wakelock">Adquirir Wakelock</string>
+    <string name="service_notification_wakerelease">Liberar Wakelock</string>
 
     <!-- Progress bar messages -->
     <string name="progress_start_step">Preparando as coisas para você&#8230;</string>
@@ -175,6 +183,8 @@
     <string name="export_success">Backup exportado com sucesso</string>
     <string name="export_failure">Impossível exportar o backup</string>
     <string name="export_started">Exportação iniciada, por favor aguarde</string>
+    <string name="start_on_boot_conflict_title">Iniciar no boot já designado!</string>
+    <string name="start_on_boot_conflict_message">UserLAnd somente suporta uma única sessão ativa.\nConfigurar esta sessão como padrão para iniciar no boot.</string>
 
     <!-- Clear support files alert -->
     <string name="alert_clear_support_files_title">Limpar todos os arquivos de suporte?</string>
@@ -187,6 +197,12 @@
     <!-- Play service error alerts -->
     <string name="alert_need_client_app_title">Não é possível encontrar um App cliente!</string>
     <string name="alert_need_client_app_message">Você precisará de um cliente SSH ou VNC ou XSDL para concluir essa ação, mas parece que você não tem a loja de jogos instalada. \n\nPor favor, instale o aplicativo cliente (SSH/VNC/XSDL) associado ao tipo de cliente da sessão para continuar.</string>
+
+    <!-- ServerService boot error alerts -->
+    <string name="alert_need_start_script_title">Comando de inicialização não pôde ser executado durante inicialização da Sessão.</string>
+    <string name="alert_need_start_script_message">Script de inicialização obrigatório /support/autostart.sh não foi encontrado.</string>
+    <string name="alert_need_profile_script_title">Comando de inicialização não pôde ser executado durante inicialização da Sessão.</string>
+    <string name="alert_need_profile_script_message">Script de inicialização obrigatório /support/userland_profile.sh não foi encontrado.</string>
 
     <!-- Permissions necessary alert -->
     <string name="alert_permissions_necessary_title">UserLAnd requer permissões!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -213,6 +213,12 @@
     <string name="alert_need_client_app_title">Can\'t find a client app!</string>
     <string name="alert_need_client_app_message">You\'ll need an SSH or VNC or XSDL client to complete this action, but it looks like you don\'t have the play store installed. \n\nPlease install the client application (SSH/VNC/XSDL) associated with the session\'s client type to continue.</string>
 
+    <!-- ServerService boot error alerts -->
+    <string name="alert_need_start_script_title">Start command was not executed on Session start up.</string>
+    <string name="alert_need_start_script_message">Obligatory start script /support/autostart.sh is missing.</string>
+    <string name="alert_need_profile_script_title">Start command was not executed on Session start up.</string>
+    <string name="alert_need_profile_script_message">Obligatory start script /support/userland_profile.sh is missing.</string>
+
     <!-- Permissions necessary alert -->
     <string name="alert_permissions_necessary_title">UserLAnd requires permissions!</string>
     <string name="alert_permissions_necessary_message">To continue, enable storage permissions to allow UserLAnd to download files and move them from external storage to app local storage.</string>

--- a/app/src/test/java/tech/ula/utils/ServerUtilityTest.kt
+++ b/app/src/test/java/tech/ula/utils/ServerUtilityTest.kt
@@ -310,6 +310,38 @@ class ServerUtilityTest {
         serverUtility.executeStartCommand(session)
     }
 
+    @Test(expected = IllegalStateException::class)
+    fun `Calling executeStartCommand on a session without a start script fails with no interactions with busyboxExecutor`() {
+        val session = Session(0, filesystemId = filesystemId)
+        session.startCommand = "ls -lah"
+
+        val folder = tempFolder.newFolder(filesystemDirName, "support")
+        val profileScriptFile = File("${folder.absolutePath}/userland_profile.sh")
+        profileScriptFile.createNewFile()
+
+        try {
+            serverUtility.executeStartCommand(session)
+        } finally {
+            verifyZeroInteractions(mockBusyboxExecutor)
+        }
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `Calling executeStartCommand on a session without a profile script fails with no interactions with busyboxExecutor`() {
+        val session = Session(0, filesystemId = filesystemId)
+        session.startCommand = "ls -lah"
+
+        val folder = tempFolder.newFolder(filesystemDirName, "support")
+        val startScriptFile = File("${folder.absolutePath}/autostart.sh")
+        startScriptFile.createNewFile()
+
+        try {
+            serverUtility.executeStartCommand(session)
+        } finally {
+            verifyZeroInteractions(mockBusyboxExecutor)
+        }
+    }
+
     @Test
     fun `Calling executeStartCommand on a session with command and files calls busybox executor`() {
         val session = Session(0, filesystemId = filesystemId)

--- a/gradlew
+++ b/gradlew
@@ -28,7 +28,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS=""
+DEFAULT_JVM_OPTS='"-Xmx64m"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -14,7 +14,7 @@ set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
+set DEFAULT_JVM_OPTS="-Xmx64m"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome


### PR DESCRIPTION
I am making an effort to keep #801 moving forward: introducing the ability to start sessions automatically after Android boots

----------------------------------------------------------------------------------------

- **Created some tests for `executeStartCommand`;**
	Asserting that:
	- Calling `executeStartCommand` on a session without a start command returns early without interecting with `busyboxExecutor`
	- Calling `executeStartCommand` on a session without a start script throws exception
	- Calling `executeStartCommand` on a session without a profile script throws exception
	- Calling `executeStartCommand` on a session without a start script fails with no interactions with `busyboxExecutor`
	- Calling `executeStartCommand` on a session without a profile script fails with no interactions with `busyboxExecutor`
	- Calling `executeStartCommand` on a session with command and files successfuly calls `busyboxExecutor`

	[This code review comment](https://github.com/CypherpunkArmory/UserLAnd/pull/801#discussion_r280921669) states the needs of tests


- **Inserted `TODO` for future refactoring added as requested by @MatthewTighe;**

	As [stated](https://github.com/CypherpunkArmory/UserLAnd/pull/801#discussion_r280921669), changes may be needed terms of code structure but a TODO may be used for now.

- **`ServerService` being prepared for handling errors on calling executeStartCommand, when start and/or profile scripts are missing;** ~~No behaviour was changed yet~~ _Latest commit implements expected behaviour, see comments bellow_;

	It is desired that the user is alerted about a failure of execution ([here](https://github.com/CypherpunkArmory/UserLAnd/pull/801#discussion_r280964107)). Preparing for [implementation choice](https://github.com/CypherpunkArmory/UserLAnd/pull/801#discussion_r280964107), by _send an intent to the MainActivity from the Service_.  

- **`executeStartCommand` now checks for start and profile scripts;**

	- Correction for bug [stated here](https://github.com/CypherpunkArmory/UserLAnd/pull/801#discussion_r280921669)

----------------------------------------------------------------------------------------

**My code should be carefully inspected due to my lack of knowlegde of the environment.** 
I could not program through the last 5+ years, never developed for mobile nor Android. I am learning about the environment, IDE, language and UserLAnd on the go.
